### PR TITLE
:sparkles: 최근 조회 장소 20곳 저장하기 기능 - 마이페이지

### DIFF
--- a/src/components/common/ThumbnailBox/index.tsx
+++ b/src/components/common/ThumbnailBox/index.tsx
@@ -1,31 +1,20 @@
 import { LabelText, LikeIcon, ThumbLabel, ThumbWrap } from './style';
 import { ReactComponent as LikeEmpty } from '@assets/like-gray.svg';
 import { ReactComponent as LikeFull } from '@assets/like-full.svg';
-import { useNavigate } from 'react-router-dom';
 
 import defaultImage from '../../../images/default.png';
 
 interface ThumbnailProps {
-  id: number;
-  label: string;
-  like: boolean;
-  imageSrc?: string;
+  data: PlacesType;
+  like?: boolean;
+  onClick?: () => void;
 }
 
-const ThumbnailBox = ({ label, like, id, imageSrc }: ThumbnailProps) => {
-  const naviagate = useNavigate();
-  const handleGoExplainPage = (title: string, id: number) => {
-    naviagate(`/place/${id}`, { state: title });
-  };
-
+const ThumbnailBox = ({ data, like, onClick }: ThumbnailProps) => {
   return (
-    <ThumbWrap
-      onClick={() => handleGoExplainPage(label, id)}
-      $imageSrc={imageSrc}
-      $defaultImageSrc={defaultImage}
-    >
+    <ThumbWrap onClick={onClick} $imageSrc={data.image_url} $defaultImageSrc={defaultImage}>
       <ThumbLabel>
-        <LabelText>{label}</LabelText>
+        <LabelText>{data.name}</LabelText>
       </ThumbLabel>
       {like ? (
         <LikeIcon>

--- a/src/components/common/ThumbnailList/index.tsx
+++ b/src/components/common/ThumbnailList/index.tsx
@@ -1,36 +1,51 @@
 import { ThumbnailListWrap } from './style';
 import ThumbnailBox from '../ThumbnailBox';
-// import Loading from '../Loading';
-// import WarningMention from '../warning';
-import { MOCKUP1 } from '@application/mock';
+import { useNavigate } from 'react-router-dom';
+import RecentViewPlaces from '@hooks/localStorage/RecentViewPlaces';
 
 interface ThumbnailListProps {
   places?: PlacesType[];
   isLoading?: boolean;
 }
 
+const MAX_RECENT_PLACES = 20;
+
 // TODO API 모두 입히면 수정하기
 const ThumbnailList = ({ places }: ThumbnailListProps) => {
+  const naviagate = useNavigate();
+  const { handleGetRecentPlaces, handleSaveRecentPlace } = RecentViewPlaces();
+
+  const handleClickThumb = (data: PlacesType) => {
+    naviagate(`/place/${data.id}`, { state: data.name });
+
+    const recentPlaces: PlacesType[] = handleGetRecentPlaces();
+    const updatedRecentPlaces = recentPlaces.filter(place => place.id !== data.id);
+
+    updatedRecentPlaces.push({
+      id: data.id,
+      image_url: data.image_url,
+      name: data.name,
+    });
+
+    if (updatedRecentPlaces.length > MAX_RECENT_PLACES) {
+      updatedRecentPlaces.shift();
+    }
+
+    handleSaveRecentPlace(updatedRecentPlaces);
+  };
+
   return places ? (
     <ThumbnailListWrap>
       {places.map(data => (
         <ThumbnailBox
           key={data.id}
-          label={data.name}
+          data={data}
           like={false}
-          id={data.id}
-          imageSrc={data.image_url}
+          onClick={() => handleClickThumb(data)}
         />
       ))}
     </ThumbnailListWrap>
-  ) : (
-    // <WarningMention text="다시 한 번 새로고침 해주세요!" />
-    <ThumbnailListWrap>
-      {MOCKUP1.map(data => (
-        <ThumbnailBox key={data.id} label={data.title} like={false} id={data.id} />
-      ))}
-    </ThumbnailListWrap>
-  );
+  ) : null;
 };
 
 export default ThumbnailList;

--- a/src/hooks/localStorage/RecentViewPlaces.ts
+++ b/src/hooks/localStorage/RecentViewPlaces.ts
@@ -1,0 +1,14 @@
+const RecentViewPlaces = () => {
+  const handleGetRecentPlaces = () => {
+    const storedData = localStorage.getItem('recentPlaces');
+    return storedData ? JSON.parse(storedData) : [];
+  };
+
+  const handleSaveRecentPlace = (places: PlacesType[]) => {
+    localStorage.setItem('recentPlaces', JSON.stringify(places));
+  };
+
+  return { handleGetRecentPlaces, handleSaveRecentPlace };
+};
+
+export default RecentViewPlaces;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -19,12 +19,14 @@ import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
 import Toast from '@components/common/Toast';
 import { useNavigate } from 'react-router-dom';
+import RecentViewPlaces from '@hooks/localStorage/RecentViewPlaces';
+import ThumbnailList from '@components/common/ThumbnailList';
 
-// TODO 최근 조회 장소, 로컬스토리지 이용하여 구현하기
 const MyPage = () => {
   const naviagte = useNavigate();
   const { toast, handleFloatingToast } = useToast();
   const { modal, handleViewModal, handleCloseModal } = useModal();
+  const { handleGetRecentPlaces } = RecentViewPlaces();
 
   const handleDeleteAccount = () => {
     handleCloseModal();
@@ -34,6 +36,8 @@ const MyPage = () => {
       naviagte('/');
     }, 2200);
   };
+
+  const storedData = handleGetRecentPlaces().reverse();
 
   return (
     <MyPageWrap>
@@ -51,6 +55,7 @@ const MyPage = () => {
         <li>최근 조회한 장소 20곳</li>
         <WithdrawTextBox onClick={handleViewModal}>회원탈퇴</WithdrawTextBox>
       </MyPageJobList>
+      <ThumbnailList places={storedData} />
       {modal && (
         <Modal onClose={handleCloseModal}>
           <ModalBox>


### PR DESCRIPTION
- localStorage 활용
- 중복없이 담기도록 제거 후 다시 넣기
- 20곳이 넘어가면 가장 먼저 담겼던 데이터 shift()를 이용해 제거 후 최근 데이터 첨부

| 최근 조회 20곳 |
|:--:|
|![ezgif com-video-to-gif](https://github.com/JJongsKim/Seoul-Walk/assets/81777778/d21e2725-eab4-47af-8091-99ffb6afd36d)|