### PR TITLE
✨ 찜 기반 추천 페이지 - 사용자별 장소추천 알고리즘 API 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,7 @@ function App() {
             <Route element={<Layout />}>
               <Route path="/" element={<MainPage userId={userId} />} />
               <Route path="/*" element={<NotFoundPage />} />
-              <Route path="/search" element={<SearchPage />} />
+              <Route path="/search" element={<SearchPage userId={userId} />} />
               <Route path="/search/:menuId" element={<CategoryPage userId={userId} />} />
               <Route path="/search/course" element={<CoursePage />} />
               <Route path="/search/map" element={<MapPage userId={userId} />} />

--- a/src/hooks/api/places/index.ts
+++ b/src/hooks/api/places/index.ts
@@ -126,3 +126,14 @@ export const useGetPlacesOfTop20 = (headerArgs?: Record<string, string>) => {
 
   return { data: data?.data.result, ...rest };
 };
+
+// - 유저별 찜 기반 장소 추천 API hook
+export const useGetPlacesOfLikeRecommend = (headerArgs?: Record<string, string>) => {
+  const { data, isLoading, ...rest } = useQuery({
+    queryKey: ['getPlacesOfLikeRecommend', headerArgs],
+    queryFn: () => api.places.getPlacesOfLikeRecommend(headerArgs),
+    retry: 1,
+  });
+
+  return { recommendData: data?.data.recommendations as PlacesType[], isLoading, ...rest };
+};

--- a/src/infra/api/instance.ts
+++ b/src/infra/api/instance.ts
@@ -15,6 +15,7 @@ import { API } from '@application/constant';
 
 interface APIResponse<T = any> {
   result: T;
+  recommendations?: T;
   hearts?: HeartPlacesType[];
   message: string;
   total_places?: number;

--- a/src/infra/api/placesApi.ts
+++ b/src/infra/api/placesApi.ts
@@ -29,6 +29,11 @@ class PlacesApi {
     });
   };
 
+  // - 유저별 찜 기반 장소 추천 API
+  getPlacesOfLikeRecommend = (headerArgs?: Record<string, string>) => {
+    return this.api.get('/places/recommend', { headers: headerArgs });
+  };
+
   // - <일반> id별 장소 상세조회 API
   getInfoByPlaceId = (placeId: number, headerArgs?: Record<string, string>) => {
     return this.api.get(`/places/place${placeId}`, { headers: headerArgs });

--- a/src/pages/DetailPage/LikeRecommendPage/index.tsx
+++ b/src/pages/DetailPage/LikeRecommendPage/index.tsx
@@ -1,11 +1,14 @@
-import SearchBar from '@components/common/SearchBar';
-import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { styled } from 'styled-components';
 
 import { DetailPageWrap } from '../style';
+import SearchBar from '@components/common/SearchBar';
 import withAuth from '@components/HOC/withAuth';
 import WarningMention from '@components/common/warning';
-import { useGetPlacesOfHeart } from '@hooks/api/heart';
+import { useGetPlacesOfLikeRecommend } from '@hooks/api/places';
+import Loading from '@components/common/Loading';
+import ThumbnailList from '@components/common/ThumbnailList';
+import { getNickname } from '@infra/api/nickname';
 
 interface LikeRecommendPageProps {
   userId: Record<string, string>;
@@ -13,28 +16,61 @@ interface LikeRecommendPageProps {
 
 const LikeRecommendPage = ({ userId }: LikeRecommendPageProps) => {
   const location = useLocation();
-  const [likeData, setLikeData] = useState(true);
-
-  const { data } = useGetPlacesOfHeart(userId);
-
-  useEffect(() => {
-    if (data.length === 0) {
-      setLikeData(false); // 찜이 담겨있지 않을 시 false
-    } else {
-      setLikeData(true); // TODO 찜이 담겨있을 시, ...
-    }
-  }, [data]);
+  const userNickname = getNickname();
+  const { recommendData, isLoading } = useGetPlacesOfLikeRecommend(userId);
 
   return (
     <DetailPageWrap>
-      <SearchBar name={`${location.state.name}`} backIcon={true} />
-      {likeData ? (
-        <div>추천 데이터 들어갈 자리</div>
+      <SearchBar name={`${location.state.custom.name}`} backIcon={true} />
+      {location.state.likeLength ? (
+        isLoading ? (
+          <LoadingContent>
+            <Loading />
+            <WaitingTextWrap>
+              <p>
+                <span>{userNickname}</span>님을 위한 장소를 추천중이에요!
+              </p>
+              <p>조금만 기다려주세요 :D</p>
+            </WaitingTextWrap>
+          </LoadingContent>
+        ) : recommendData.length === 0 ? (
+          <WarningMention text="추천을 위해 찜을 더 눌러주세요 :D" />
+        ) : (
+          <ThumbnailList places={recommendData} isLoading={isLoading} />
+        )
       ) : (
         <WarningMention text="해당 기능을 사용하시려면 장소를 찜해주세요!" />
       )}
     </DetailPageWrap>
   );
 };
+
+const LoadingContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const WaitingTextWrap = styled.div`
+  position: absolute;
+  top: 60%;
+  left: 50%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+
+  transform: translate(-50%, -60%);
+
+  p {
+    margin: 10px 0;
+    color: ${({ theme }) => theme.colors.gray};
+    ${({ theme }) => theme.font.B_14};
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.green};
+  }
+`;
 
 export default withAuth(LikeRecommendPage);

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -1,4 +1,4 @@
-import SearchBar from '@components/common/SearchBar';
+import { useNavigate } from 'react-router-dom';
 
 import {
   MenuDivideLine,
@@ -9,10 +9,41 @@ import {
   SearchPageWrap,
 } from './style';
 import { CUSTOM_MENU, MENU } from '@application/constant';
-import { useNavigate } from 'react-router-dom';
+import { useGetPlacesOfHeart } from '@hooks/api/heart';
+import SearchBar from '@components/common/SearchBar';
+import { useEffect } from 'react';
 
-const SearchPage = () => {
+interface SearchPageProps {
+  userId: Record<string, string>;
+}
+
+const SearchPage = ({ userId }: SearchPageProps) => {
   const navigate = useNavigate();
+  const { data, refetch } = useGetPlacesOfHeart(userId);
+
+  const handleMoveCustomMenu = (
+    customPath: string,
+    custom: {
+      name: string;
+      svg: string;
+      path: string;
+    },
+  ) => {
+    if (custom.name === '찜 기반 추천') {
+      navigate(`${customPath}`, {
+        state: {
+          likeLength: data.length,
+          custom,
+        },
+      });
+    } else {
+      navigate(`${customPath}`, { state: custom });
+    }
+  };
+
+  useEffect(() => {
+    refetch();
+  }, []);
 
   return (
     <SearchPageWrap>
@@ -28,7 +59,7 @@ const SearchPage = () => {
       <MenuDivideLine />
       <MenuListWrap>
         {CUSTOM_MENU.map(custom => (
-          <MenuWrap key={custom.name} onClick={() => navigate(`${custom.path}`, { state: custom })}>
+          <MenuWrap key={custom.name} onClick={() => handleMoveCustomMenu(custom.path, custom)}>
             <MenuIcon src={custom.svg} />
             <MenuName>{custom.name}</MenuName>
           </MenuWrap>


### PR DESCRIPTION
- **사용자별 장소 추천 알고리즘 API 연결**
  - 유사도 행렬 계산으로 인해 타 API에 비해 로딩 지속 시간/무한스크롤에서의 응답 반환 시간이 길다는 문제점 발견
  - 초창기 로딩을 좀 기다리더라도 데이터를 한 번에 보여주는 것으로 변경
  - 다른 페이지의 로딩들과 다르게 문구 추가

|찜 기반 추천 페이지|
|:--:|
|![추천api](https://github.com/JJongsKim/Seoul-Walk/assets/81777778/a8d2a267-2cdb-4638-9eb6-710e75eef6da)
|